### PR TITLE
Auto-localize config paths: prefer local files over S3 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,28 @@ For AWS S3, this is currently not set up and is generally not recommended (we wa
 The `HF_TOKEN` is set up already on upstream. However, this may not be set up on individual forks. To add your own `HF_TOKEN` to individual forks, you can add it in "Settings". See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
 
 ## Citation
-Coming soon.
+
+Technical Report:
+```bibtex
+@techreport{mercat2026vlafoundry,
+  title       = {{VLA Foundry}: A Unified Framework for Training Vision-Language-Action Models},
+  author      = {Mercat, Jean and Keh, Sedrick and Arora, Kushal and Huang, Isabella and Shah, Paarth and Nishimura, Haruki and Iwase, Shun and Liu, Katherine},
+  year        = {2026},
+  institution = {Toyota Research Institute},
+  note        = {Jean Mercat and Sedrick Keh contributed equally}
+}
+```
+
+Software:
+```bibtex
+@software{mercat2026vlafoundry_code,
+  title   = {{VLA Foundry}: A Unified Framework for Training Vision-Language-Action Models},
+  author  = {Mercat, Jean and Keh, Sedrick and Arora, Kushal and Huang, Isabella and Shah, Paarth and Nishimura, Haruki and Iwase, Shun and Liu, Katherine},
+  year    = {2026},
+  url     = {https://github.com/TRI-ML/vla_foundry},
+  version = {1.0.0}
+}
+```
 
 ## Acknowledgements
 Parts of this repo were built from parts of [open_clip](https://github.com/mlfoundations/open_clip), [open_lm](https://github.com/mlfoundations/open_lm), and [nanoVLM](https://github.com/huggingface/nanoVLM/tree/main).

--- a/vla_foundry/inference/robotics/inference_policy.py
+++ b/vla_foundry/inference/robotics/inference_policy.py
@@ -79,9 +79,7 @@ class InferenceDiffusionPolicy(Policy):
         self.model_config_path = f"{checkpoint_directory}/config.yaml"
 
         # Load model configuration first to get EMA enabled setting
-        self.cfg = load_experiment_params_from_yaml(
-            self.model_config_path, localize_params=not self.model_config_path.startswith("s3://")
-        )
+        self.cfg = load_experiment_params_from_yaml(self.model_config_path)
         self.ema_enabled = self.cfg.ema.enabled
 
         if checkpoint_name is None or checkpoint_name == "":
@@ -109,9 +107,7 @@ class InferenceDiffusionPolicy(Policy):
         self.gripper_debounce_close_threshold = gripper_debounce_close_threshold
 
         # Reload the config (the second call overwrites self.cfg via draccus).
-        self.cfg = load_experiment_params_from_yaml(
-            self.model_config_path, localize_params=not self.model_config_path.startswith("s3://")
-        )
+        self.cfg = load_experiment_params_from_yaml(self.model_config_path)
         # Use load_pretrained=False to skip downloading pretrained weights (they'll be loaded from checkpoint)
         self.model = create_model(self.cfg.model, load_pretrained=False)
 

--- a/vla_foundry/models/base_model.py
+++ b/vla_foundry/models/base_model.py
@@ -55,16 +55,7 @@ class BaseModel(nn.Module, metaclass=BaseModelMeta):
         # vlm_foundry_backbone constructor can resolve vlm_config_model.yaml
         # from the published repo on its own.
         config_path = f"{path}/config.yaml" if not path.endswith(".yaml") else path
-        # localize_params rewrites s3:// entries in the loaded config to sibling
-        # files next to config.yaml (when they exist), so a locally-synced
-        # training directory doesn't require AWS credentials just to read its
-        # preprocessing_config / stats.json. Skip for S3-hosted configs; those
-        # are already remote, and we can't localize what we can't fetch.
-        train_params = load_params_from_yaml(
-            TrainExperimentParams,
-            config_path,
-            localize_params=not config_path.startswith("s3://"),
-        )
+        train_params = load_params_from_yaml(TrainExperimentParams, config_path)
 
         model = create_model(train_params.model, load_pretrained=False)
 

--- a/vla_foundry/params/train_experiment_params.py
+++ b/vla_foundry/params/train_experiment_params.py
@@ -166,7 +166,9 @@ class TrainExperimentParams(BaseParams):
         #     raise ValueError(f"--fsdp can only be specified in distributed mode.")
 
 
-def load_params_from_yaml(params_class: type[BaseParams], path: str, localize_params: bool = False) -> BaseParams:
+def load_params_from_yaml(
+    params_class: type[BaseParams], path: str, localize_params: bool | None = None
+) -> BaseParams:
     """
     Load a draccus params object from a yaml file with support for s3 and hf:// paths.
 
@@ -178,13 +180,18 @@ def load_params_from_yaml(params_class: type[BaseParams], path: str, localize_pa
     Args:
         params_class: dataclass type to load.
         path: local filesystem path, S3 URI, or ``hf://repo_id/file.yaml`` to the YAML file.
-        localize_params: if True, first localize all paths in the config before loading.
+        localize_params: if True, localize S3 paths inside the config to local siblings
+            when they exist. If None (the default), auto-detect: localize when the config
+            itself is local, skip when it lives on S3.
     """
     original_path = path
 
     # Resolve hf:// paths to local cache before anything else
     if path.startswith("hf://"):
         path = _resolve_hf_path(path)
+
+    if localize_params is None:
+        localize_params = not original_path.startswith("s3://")
 
     if localize_params:
         config_dict = yaml_load(path)
@@ -240,9 +247,10 @@ def get_config_origin(params_obj) -> str | None:
     return _ORIGIN_BY_ID.get(id(params_obj))
 
 
-def load_experiment_params_from_yaml(path: str, localize_params: bool = False) -> TrainExperimentParams:
+def load_experiment_params_from_yaml(path: str, localize_params: bool | None = None) -> TrainExperimentParams:
     """
     Convenience wrapper to load `TrainExperimentParams` from YAML.
-    If `localize_params` is True, first localize all paths in the config before loading.
+    If `localize_params` is None (the default), auto-detect: localize when the config
+    is local, skip when it lives on S3.
     """
     return load_params_from_yaml(TrainExperimentParams, path, localize_params)


### PR DESCRIPTION
## Summary

- Changes `localize_params` default from `False` to `None` (auto-detect) in `load_params_from_yaml` and `load_experiment_params_from_yaml`
- When `None`, automatically localizes S3 paths in configs when the config itself is loaded from a local path (i.e. `not path.startswith("s3://")`)
- Removes redundant explicit `localize_params=not path.startswith("s3://")` from `inference_policy.py` and `base_model.py` since the default now handles this
- Fixes inconsistency where some inference entry points (`inference.py`, `inference_vlm.py`, `data_explorer_gradio.py`) never localized paths even when loading from local directories

### Before
Callers had to remember to pass `localize_params=not config_path.startswith("s3://")` — easy to forget, and several inference scripts didn't do it. Loading a locally-synced checkpoint directory could still try to fetch from S3 for stats.json, preprocessing_config, etc.

### After
Local configs automatically resolve embedded S3 paths to local siblings when they exist. S3-hosted configs skip localization as before. Explicit `True`/`False` still works for callers that need to override.

## Test plan
- [x] All 25 `test_argument_loading_parsing.py` tests pass
- [ ] Verify inference from a locally-synced checkpoint directory works without AWS credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)