### PR TITLE
check config params validity.

### DIFF
--- a/vla_foundry/main.py
+++ b/vla_foundry/main.py
@@ -393,7 +393,8 @@ def main():
         torch.distributed.destroy_process_group()
 
 def check_cfg(cfg : TrainExperimentParams):
-    assert cfg.data.img_num_tokens == (cfg.model.vit.img_size // cfg.model.vit.patch_size) ** 2, "parameter img_num_tokens is expected to be equal to the patches count."
+    if cfg.model.type == "vlm":
+        assert cfg.data.img_num_tokens == (cfg.model.vit.img_size // cfg.model.vit.patch_size) ** 2, "parameter img_num_tokens is expected to be equal to the patches count."
     # other like warning also can go here
     
 if __name__ == "__main__":

--- a/vla_foundry/main.py
+++ b/vla_foundry/main.py
@@ -61,6 +61,10 @@ def main():
     """
     # Parse config.
     cfg = draccus.parse(config_class=TrainExperimentParams)
+    
+    # config check
+    assert cfg.data.img_num_tokens == (cfg.model.vit.img_size // cfg.model.vit.patch_size) ** 2, "parameter img_num_tokens is expected to be equal to the patches count."
+    
     if cfg.resolve_configs:
         # Resolve configs for debugging. Program stops here if the flag is received.
         if is_master(cfg):

--- a/vla_foundry/main.py
+++ b/vla_foundry/main.py
@@ -62,9 +62,6 @@ def main():
     # Parse config.
     cfg = draccus.parse(config_class=TrainExperimentParams)
     
-    # check config
-    check_cfg(cfg)
-    
     if cfg.resolve_configs:
         # Resolve configs for debugging. Program stops here if the flag is received.
         if is_master(cfg):
@@ -392,10 +389,6 @@ def main():
     if cfg.distributed.use_distributed and torch.distributed.is_initialized():
         torch.distributed.destroy_process_group()
 
-def check_cfg(cfg : TrainExperimentParams):
-    if cfg.model.type == "vlm":
-        assert cfg.data.img_num_tokens == (cfg.model.vit.img_size // cfg.model.vit.patch_size) ** 2, "parameter img_num_tokens is expected to be equal to the patches count."
-    # other like warning also can go here
     
 if __name__ == "__main__":
     main()

--- a/vla_foundry/main.py
+++ b/vla_foundry/main.py
@@ -62,8 +62,8 @@ def main():
     # Parse config.
     cfg = draccus.parse(config_class=TrainExperimentParams)
     
-    # config check
-    assert cfg.data.img_num_tokens == (cfg.model.vit.img_size // cfg.model.vit.patch_size) ** 2, "parameter img_num_tokens is expected to be equal to the patches count."
+    # check config
+    check_cfg(cfg)
     
     if cfg.resolve_configs:
         # Resolve configs for debugging. Program stops here if the flag is received.
@@ -392,6 +392,9 @@ def main():
     if cfg.distributed.use_distributed and torch.distributed.is_initialized():
         torch.distributed.destroy_process_group()
 
-
+def check_cfg(cfg : TrainExperimentParams):
+    assert cfg.data.img_num_tokens == (cfg.model.vit.img_size // cfg.model.vit.patch_size) ** 2, "parameter img_num_tokens is expected to be equal to the patches count."
+    # other like warning also can go here
+    
 if __name__ == "__main__":
     main()

--- a/vla_foundry/main.py
+++ b/vla_foundry/main.py
@@ -61,7 +61,6 @@ def main():
     """
     # Parse config.
     cfg = draccus.parse(config_class=TrainExperimentParams)
-    
     if cfg.resolve_configs:
         # Resolve configs for debugging. Program stops here if the flag is received.
         if is_master(cfg):
@@ -389,6 +388,6 @@ def main():
     if cfg.distributed.use_distributed and torch.distributed.is_initialized():
         torch.distributed.destroy_process_group()
 
-    
+
 if __name__ == "__main__":
     main()

--- a/vla_foundry/params/train_experiment_params.py
+++ b/vla_foundry/params/train_experiment_params.py
@@ -165,7 +165,7 @@ class TrainExperimentParams(BaseParams):
         # Commenting out for now.
         # if self.distributed.fsdp and not self.distributed.use_distributed:
         #     raise ValueError(f"--fsdp can only be specified in distributed mode.")
-        
+
         if self.model.type == "vlm":
             img_tok_warning = "parameter img_num_tokens is expected to be equal to the patches count divided by square of projector_pixel_shuffle_factor."
             assert self.data.img_num_tokens == utils.compute_num_image_tokens(self.model.vit), img_tok_warning

--- a/vla_foundry/params/train_experiment_params.py
+++ b/vla_foundry/params/train_experiment_params.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 import yaml
 
 from vla_foundry.data.utils import epochs_to_samples
+from vla_foundry.models import utils
 from vla_foundry.file_utils import localize_paths, yaml_load
 from vla_foundry.hf_hub import resolve_hf_path as _resolve_hf_path
 from vla_foundry.params.base_params import BaseParams
@@ -164,6 +165,10 @@ class TrainExperimentParams(BaseParams):
         # Commenting out for now.
         # if self.distributed.fsdp and not self.distributed.use_distributed:
         #     raise ValueError(f"--fsdp can only be specified in distributed mode.")
+        
+        if self.model.type == "vlm":
+            img_tok_warning = "parameter img_num_tokens is expected to be equal to the patches count divided by square of projector_pixel_shuffle_factor."
+            assert self.data.img_num_tokens == utils.compute_num_image_tokens(self.model.vit), img_tok_warning
 
 
 def load_params_from_yaml(params_class: type[BaseParams], path: str, localize_params: bool = False) -> BaseParams:


### PR DESCRIPTION
## Description
because cfg.data.img_num_tokens can be set independently, so to avoid the inconsistency, check below after parsing config.
cfg.data.img_num_tokens == (cfg.model.vit.img_size // cfg.model.vit.patch_size) ** 2

## Tests


## Related PRs/Issues


